### PR TITLE
Add bundler as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Use as a complement to other tools at your own risk.
 ## Prerequisites
 
 * Ruby 2.3 or newer
+* Bundler `gem install bundler`
 
 ## Installation
 


### PR DESCRIPTION
Bundler is required to run depspy or else you get the following error:

```
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler (LoadError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/librariesio-gem-parser-1.0.0/lib/gemnasium/parser/gemfile.rb:1:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/librariesio-gem-parser-1.0.0/lib/gemnasium/parser.rb:2:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/bibliothecary-6.3.1/lib/bibliothecary/parsers/rubygems.rb:1:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/bibliothecary-6.3.1/lib/bibliothecary.rb:6:in `block in <top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/bibliothecary-6.3.1/lib/bibliothecary.rb:5:in `each'
	from /Library/Ruby/Gems/2.3.0/gems/bibliothecary-6.3.1/lib/bibliothecary.rb:5:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/lib/dependency_spy.rb:20:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/lib/dependency_spy/cli.rb:20:in `require_relative'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/lib/dependency_spy/cli.rb:20:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/bin/dependency_spy:3:in `<top (required)>'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/bin/depspy:3:in `load'
	from /Library/Ruby/Gems/2.3.0/gems/dependency_spy-0.1.4/bin/depspy:3:in `<top (required)>'
	from /usr/local/bin/depspy:22:in `load'
	from /usr/local/bin/depspy:22:in `<main>'
```