### PR TITLE
Add option to ignore vulnerabilities by the id. (#4)

### DIFF
--- a/lib/dependency_spy.rb
+++ b/lib/dependency_spy.rb
@@ -30,7 +30,7 @@ module DependencySpy
 
     def self.check(options)
       path = options[:path] || Dir.pwd
-      files = options[:file]
+      files = options[:files]
       platform = options[:platform]
       database_path = options[:database_path] || YAVDB::Constants::DEFAULT_YAVDB_DATABASE_PATH
       offline = options[:offline] || false

--- a/lib/dependency_spy.rb
+++ b/lib/dependency_spy.rb
@@ -28,7 +28,14 @@ require_relative 'dependency_spy/semver'
 module DependencySpy
   class API
 
-    def self.check(path = Dir.pwd, files = nil, platform = nil, database_path = YAVDB::Constants::DEFAULT_YAVDB_DATABASE_PATH, offline = false)
+    def self.check(options)
+      path = options[:path] || Dir.pwd
+      files = options[:file]
+      platform = options[:platform]
+      database_path = options[:database_path] || YAVDB::Constants::DEFAULT_YAVDB_DATABASE_PATH
+      offline = options[:offline] || false
+      ignore = options[:ignore] || []
+
       if !File.exist?(database_path) && offline
         puts 'No local database found. Cannot obtain database since offline mode is enabled.'
         exit(10)
@@ -65,8 +72,9 @@ module DependencySpy
             vulnerable = vuln.vulnerable_versions ? vuln.vulnerable_versions.any? { |vv| DependencySpy::SemVer.intersects(vv, version) } : false
             unaffected = vuln.unaffected_versions ? vuln.unaffected_versions.any? { |vu| DependencySpy::SemVer.intersects(vu, version) } : false
             patched    = vuln.patched_versions ? vuln.patched_versions.any? { |vp| DependencySpy::SemVer.intersects(vp, version) } : false
+            ignored    = ignore.include?(vuln.id)
 
-            if unaffected || patched
+            if unaffected || patched || ignored
               false
             else
               vulnerable

--- a/lib/dependency_spy/cli.rb
+++ b/lib/dependency_spy/cli.rb
@@ -49,8 +49,9 @@ module DependencySpy
     method_option('offline', :type => :boolean, :default => false)
     method_option('severity-threshold', :aliases => :s, :type => :string, :enum => YAVDB::Constants::SEVERITIES, :default => 'low')
     method_option('with-color', :type => :boolean, :default => true)
+    method_option('ignore', :aliases => :i, :type => :array, :default => [])
     def check
-      manifests = API.check(options['path'], options['files'], options['platform'], options['database-path'], options['offline'])
+      manifests = API.check(options)
 
       formatted_output = if (options['formatter'] == 'text') && !options['output-path'] && options['with-color']
                            DependencySpy::Formatters::Text.format(manifests, options['severity-threshold'])

--- a/spec/dependency_spy_spec.rb
+++ b/spec/dependency_spy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 RSpec.describe DependencySpy::API do
   describe 'check' do
-    detected_manifests = DependencySpy::API.check('examples')
+    detected_manifests = DependencySpy::API.check({ path: 'examples' })
 
     it 'can read all manifests inside examples' do
       expect(detected_manifests).to have(5).items
@@ -48,6 +48,21 @@ RSpec.describe DependencySpy::API do
       dependencies    = manifests.map(&:dependencies).flatten
       vulnerabilities = dependencies.map(&:vulnerabilities).flatten
       expect(vulnerabilities).to have(3).items
+    end
+
+    it 'can ignore vulnerabilities by id' do
+      manifests       = detected_manifests.select { |m| m.platform == 'rubygems' }
+      dependencies    = manifests.map(&:dependencies).flatten
+      vulnerabilities = dependencies.map(&:vulnerabilities).flatten
+      select_count = vulnerabilities.select { |v| v.id == 'snykio:rubygems:rubocop:CVE-2017-8418' }.count
+      expect(select_count).to be(1)
+
+      filtered_detected_manifests = DependencySpy::API.check({ path: 'examples', ignore: ['snykio:rubygems:rubocop:CVE-2017-8418'] })
+      manifests       = filtered_detected_manifests.select { |m| m.platform == 'rubygems' }
+      dependencies    = manifests.map(&:dependencies).flatten
+      vulnerabilities = dependencies.map(&:vulnerabilities).flatten
+      select_count = vulnerabilities.select { |v| v.id == 'snykio:rubygems:rubocop:CVE-2017-8418' }.count
+      expect(select_count).to be(0)
     end
   end
 end

--- a/spec/dependency_spy_spec.rb
+++ b/spec/dependency_spy_spec.rb
@@ -18,7 +18,7 @@ require 'spec_helper'
 
 RSpec.describe DependencySpy::API do
   describe 'check' do
-    detected_manifests = DependencySpy::API.check({ path: 'examples' })
+    detected_manifests = DependencySpy::API.check(:path => 'examples')
 
     it 'can read all manifests inside examples' do
       expect(detected_manifests).to have(5).items
@@ -57,7 +57,7 @@ RSpec.describe DependencySpy::API do
       select_count = vulnerabilities.select { |v| v.id == 'snykio:rubygems:rubocop:CVE-2017-8418' }.count
       expect(select_count).to be(1)
 
-      filtered_detected_manifests = DependencySpy::API.check({ path: 'examples', ignore: ['snykio:rubygems:rubocop:CVE-2017-8418'] })
+      filtered_detected_manifests = DependencySpy::API.check(:path => 'examples', :ignore => ['snykio:rubygems:rubocop:CVE-2017-8418'])
       manifests       = filtered_detected_manifests.select { |m| m.platform == 'rubygems' }
       dependencies    = manifests.map(&:dependencies).flatten
       vulnerabilities = dependencies.map(&:vulnerabilities).flatten


### PR DESCRIPTION
* Add --ignore option to pass in list of vulnerability ids to ignore.
* --ignore is a comma separated list.
* Refactored the check method argument to options hash. This was done
  to avoid listing all options one by one in the method argument and
  also RuboCop was failing for 'Avoid parameter lists longer than 5
  parameters.'
* Added rspec test around the --ignore option.
* Fix for Issue #4 