### PR TITLE
CLI: Assign :database_path to value from 'database-path' in options.

### DIFF
--- a/lib/dependency_spy/cli.rb
+++ b/lib/dependency_spy/cli.rb
@@ -51,7 +51,10 @@ module DependencySpy
     method_option('with-color', :type => :boolean, :default => true)
     method_option('ignore', :aliases => :i, :type => :array, :default => [])
     def check
-      manifests = API.check(options)
+      the_options = options.dup
+      the_options[:database_path] = the_options[:"database-path"]
+      the_options.freeze
+      manifests = API.check(the_options)
 
       formatted_output = if (options['formatter'] == 'text') && !options['output-path'] && options['with-color']
                            DependencySpy::Formatters::Text.format(manifests, options['severity-threshold'])


### PR DESCRIPTION
Simple handling for multi-word argument name.
Only 'database-path' is passed into ::API check function.

Likely backward compatible as setting was never honored before.

Closes #15.